### PR TITLE
Debug easeFn not a function error

### DIFF
--- a/udbm-frontend/src/pages/SlowQueryAnalysis.js
+++ b/udbm-frontend/src/pages/SlowQueryAnalysis.js
@@ -386,8 +386,7 @@ const SlowQueryAnalysis = () => {
     animation: {
       appear: {
         animation: 'scale-in-y',
-        duration: 800,
-        easing: 'easeOutCubic'
+        duration: 800
       }
     },
     autoFit: true,


### PR DESCRIPTION
Fix `easeFn is not a function` runtime error by removing an unrecognized `easing` property from the chart animation configuration.

The `@ant-design/charts` library did not recognize `'easeOutCubic'` as a valid easing function string, leading to a `TypeError` when the animation system attempted to call it. Removing this property allows the chart to use its default easing, resolving the issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-34f32d7f-0947-42df-a577-3ac40d884cc8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-34f32d7f-0947-42df-a577-3ac40d884cc8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

