### PR TITLE
Fix eslint undefined useNavigate error

### DIFF
--- a/udbm-frontend/src/pages/PerformanceDashboard.js
+++ b/udbm-frontend/src/pages/PerformanceDashboard.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   Card, Row, Col, Statistic, Progress, Alert, Spin, Select,
   Button, Tabs, Table, Tag, Space, Tooltip, message, Switch,


### PR DESCRIPTION
Add `useNavigate` import to resolve ESLint `no-undef` error.

---
<a href="https://cursor.com/background-agent?bcId=bc-349a0128-2064-4bd1-a928-2497b4c8ad05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-349a0128-2064-4bd1-a928-2497b4c8ad05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

